### PR TITLE
chore: add eslint-plugin-flowtype errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,11 @@
     ]
   },
   "xo": {
-    "esnext": true
+    "esnext": true,
+    "plugins": ["flowtype-errors"],
+    "rules": {
+      "flowtype-errors/show-errors": 2
+    }
   },
   "tipi": {
     "version": "3.0.0",
@@ -68,6 +72,7 @@
     "babel-register": "6.16.3",
     "dependency-check": "2.6.0",
     "documentation": "4.0.0-beta10",
+    "eslint-plugin-flowtype-errors": "1.2.4",
     "flow-bin": "0.33.0",
     "tipi-cli": "1.0.0",
     "unexpected": "10.18.1",


### PR DESCRIPTION
depends on https://github.com/amilajack/eslint-plugin-flowtype-errors/issues/23 being published
